### PR TITLE
Feature/3/add brotli compression

### DIFF
--- a/DESIGN_BROTLI.md
+++ b/DESIGN_BROTLI.md
@@ -1,0 +1,524 @@
+# Brotli 압축 기능 추가 설계 스케치
+
+## 개요
+현재 `gzip`과 `deflate`만 지원하는 미들웨어에 `brotli` 압축 기능을 추가합니다.
+기존 아키텍처를 최대한 활용하여 일관성 있게 확장합니다.
+
+---
+
+## 1. 파일별 수정 계획
+
+### 1.1 `src/asgi_http_compression/compressors.py`
+**목적**: Brotli 압축기를 추가
+
+**수정 내용**:
+- `BrotliCompressor` 클래스 추가
+- `brotli` 패키지 import (optional dependency 처리)
+- 기존 `BaseCompressor` 인터페이스 준수 (incremental compression 지원)
+
+**구체적 구현**:
+```python
+# 파일 상단에 추가 (기존 import 아래에 추가)
+# 기존: import zlib
+# 기존: from abc import ABC, abstractmethod
+# 기존: from typing import Protocol
+
+try:
+    import brotli
+except ImportError:
+    brotli = None
+
+# 가용 여부 플래그 추가 (다른 모듈에서 사용 가능)
+BROTLI_AVAILABLE = brotli is not None
+
+# ... 기존 Compressor Protocol, BaseCompressor, GzipCompressor, DeflateCompressor ...
+
+# 파일 끝에 클래스 추가
+class BrotliCompressor(BaseCompressor):
+    def __init__(self, level: int = 4) -> None:
+        if brotli is None:
+            raise ImportError(
+                "brotli extra is required. Install with: pip install 'asgi-http-compression[brotli]'"
+            )
+        self._compressor = brotli.Compressor(quality=level)
+    
+    def compress(self, data: bytes) -> bytes:
+        """스트리밍 압축을 위한 incremental compress"""
+        return self._compressor.process(data)
+    
+    def flush(self) -> bytes:
+        """압축 완료 및 남은 데이터 반환"""
+        return self._compressor.finish()
+```
+
+**참고**: `brotli.Compressor` API 확인 필요
+- `brotli` 라이브러리의 `Compressor` 클래스는 `process(data: bytes) -> bytes`와 `finish() -> bytes` 메서드를 제공합니다.
+- `quality` 파라미터는 0-11 범위의 정수입니다 (기본값 4 권장).
+- `process()`로 데이터를 압축하고, 마지막에 `finish()`로 스트림을 완결해야 `brotli.decompress()`로 정상 복원 가능합니다.
+
+**주의사항**:
+- `brotli.Compressor`는 상태를 가지는 객체이므로 `compress()`와 `flush()`를 분리해서 사용 가능
+- `level`은 `quality` 파라미터로 전달 (0-11 범위, 기본값 4 권장)
+- `BROTLI_AVAILABLE` 플래그를 export하여 middleware와 테스트에서 사용 가능하도록 함
+
+---
+
+### 1.2 `src/asgi_http_compression/middleware.py`
+**목적**: Brotli를 압축 옵션으로 등록하고 협상에 포함
+
+**수정 내용**:
+1. `BrotliCompressor` import 추가 (optional, try-except로 처리)
+2. `__init__`에 `brotli_level` 파라미터 추가
+3. `compressor_factories`에 `"br"` 등록 (우선순위: br > gzip > deflate)
+4. `_select_encoding` 메서드는 수정 불필요 (이미 `compressor_factories`의 키를 순회하므로 자동 인식)
+
+**구체적 구현**:
+```python
+# import 섹션 수정 (기존 import 아래에 추가)
+from asgi_http_compression.compressors import (
+    DeflateCompressor,
+    GzipCompressor,
+    BrotliCompressor,
+    BROTLI_AVAILABLE,
+)
+
+# __init__ 메서드 수정
+def __init__(
+    self,
+    app: ASGIApp,
+    minimum_size: int = 500,
+    gzip_level: int = 9,
+    deflate_level: int = 6,
+    brotli_level: int = 4,  # 추가
+) -> None:
+    self.app = app
+    self.minimum_size = minimum_size
+
+    # NOTE: Register the supported compression methods and their factories
+    # NOTE: The order is important: list the ones the server prefers first
+    self.compressor_factories: dict[str, Callable[[], Any]] = {}
+
+    # Brotli를 가장 먼저 등록 (우선순위 높음)
+    # BROTLI_AVAILABLE 플래그로 실제 brotli 패키지 설치 여부 확인
+    if BROTLI_AVAILABLE:
+        self.compressor_factories["br"] = lambda: BrotliCompressor(level=brotli_level)
+    
+    self.compressor_factories["gzip"] = lambda: GzipCompressor(level=gzip_level)
+    self.compressor_factories["deflate"] = lambda: DeflateCompressor(level=deflate_level)
+```
+
+**주의사항**:
+- `BROTLI_AVAILABLE` 플래그를 사용하여 실제 `brotli` 패키지 설치 여부를 확인
+- `brotli` 패키지가 없으면 `"br"`을 등록하지 않음 (graceful degradation)
+- `"br"`은 HTTP 표준에서 사용하는 Brotli 인코딩 이름
+- 우선순위는 `compressor_factories`의 순서에 따라 결정됨 (현재 `_select_encoding`은 순서대로 체크)
+- `_select_encoding` 메서드는 수정 불필요 (이미 `compressor_factories`의 키를 순회하므로 `"br"`이 등록되면 자동으로 인식됨)
+- `BrotliCompressor` 클래스는 항상 import 가능하지만, `brotli` 패키지가 없으면 생성 시 `ImportError` 발생
+
+---
+
+### 1.3 `src/asgi_http_compression/responder.py`
+**목적**: 변경 없음 (이미 streaming/non-streaming 모두 지원)
+
+**확인 사항**:
+- `CompressionResponder`는 이미 `Compressor` 프로토콜을 사용하므로 추가 수정 불필요
+- `compress()`와 `flush()` 메서드만 있으면 동작함
+- streaming 응답 처리 로직도 이미 구현되어 있음
+
+---
+
+### 1.4 `tests/test_compressors.py`
+**목적**: Brotli 압축기 단위 테스트 추가
+
+**수정 내용**:
+- `BrotliCompressor`를 테스트에 포함
+- 기존 fixture에 `BrotliCompressor` 추가 (optional)
+- Brotli 전용 테스트 케이스 추가
+
+**구체적 구현**:
+```python
+# import 추가
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression.compressors import BrotliCompressor
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+# fixture 수정 (optional로 추가)
+@pytest.fixture(params=[GzipCompressor, DeflateCompressor] + ([BrotliCompressor] if BROTLI_AVAILABLE else []))
+def compressor(request):
+    return request.param()
+
+# Brotli 전용 테스트 추가
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+def test_brotli_compressor():
+    import brotli
+    compressor = BrotliCompressor(level=4)
+    original_data = b"Hello, World!" * 10
+    compressed = compressor.compress(original_data)
+    flushed = compressor.flush()
+    full_compressed_data = compressed + flushed
+    decompressed = brotli.decompress(full_compressed_data)
+    assert decompressed == original_data
+```
+
+**주의사항**:
+- `import brotli`를 직접 시도하여 실제 패키지 설치 여부를 확인
+- `from asgi_http_compression.compressors import BrotliCompressor`는 항상 성공할 수 있으므로, 실제 `brotli` 모듈 존재 여부를 기준으로 판단
+- `BROTLI_AVAILABLE`이 `False`면 fixture에서 `BrotliCompressor`를 제외하고, 전용 테스트는 skip됨
+
+---
+
+### 1.5 `tests/test_responder.py` (또는 새 파일 `tests/test_brotli.py`)
+**목적**: Brotli를 사용한 end-to-end 테스트 작성
+
+**새 파일 생성**: `tests/test_brotli.py`
+
+**테스트 시나리오**:
+
+1. **기본 Brotli 압축 테스트**
+   - `Accept-Encoding: br` 헤더로 요청
+   - `Content-Encoding: br` 확인
+   - 압축 해제 후 원본 데이터 확인
+
+2. **Brotli 비지원 클라이언트 테스트**
+   - `Accept-Encoding: gzip`만 보냈을 때 `br`이 나오지 않는지 확인
+
+3. **우선순위 테스트**
+   - `Accept-Encoding: br, gzip` → `br` 선택 확인
+   - `Accept-Encoding: gzip, br` → `br` 선택 확인 (서버 우선순위)
+
+4. **minimum_size 조건 테스트**
+   - 작은 응답 → 압축 안 됨
+   - 큰 응답 → 압축 됨
+
+5. **StreamingResponse 테스트**
+   - 여러 chunk로 나뉜 응답도 Brotli로 압축되는지 확인
+   - `Content-Length` 제거 확인
+
+6. **이미 Content-Encoding이 있는 응답 처리**
+   - 기존 인코딩이 있으면 Brotli 적용 안 됨
+
+**구체적 구현 예시**:
+```python
+import pytest
+
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression.compressors import BrotliCompressor
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+from asgi_http_compression.responder import CompressionResponder
+
+# test_responder.py의 MockSend, mock_app, streaming_app 등을 재사용
+from tests.test_responder import MockSend, mock_app, streaming_app, app_with_encoding
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_basic_compression():
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=mock_app,
+        compressor=compressor,
+        minimum_size=5,
+        encoding_name="br",
+    )
+    
+    await responder(scope={}, receive=None, send=send)
+    
+    assert len(send.messages) == 2
+    start_message, body_message = send.messages
+    
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"br"
+    
+    # 압축 해제 확인
+    compressed_body = body_message["body"]
+    decompressed = brotli.decompress(compressed_body)
+    assert decompressed == b"Hello, World!"
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_streaming_response():
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=streaming_app,
+        compressor=compressor,
+        minimum_size=1,
+        encoding_name="br",
+    )
+    
+    await responder(scope={}, receive=None, send=send)
+    
+    assert len(send.messages) == 3
+    start_message, body1, body2 = send.messages
+    
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"br"
+    assert b"content-length" not in headers
+    
+    # 전체 압축 데이터 수집 및 압축 해제
+    full_compressed = body1["body"] + body2["body"]
+    decompressed = brotli.decompress(full_compressed)
+    assert decompressed == b"Streaming part 2"
+
+# test_responder.py의 app_with_encoding도 재사용 가능
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_respects_existing_content_encoding():
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=app_with_encoding,
+        compressor=compressor,
+        minimum_size=1,
+        encoding_name="br",
+    )
+    
+    await responder(scope={}, receive=None, send=send)
+    
+    assert len(send.messages) == 2
+    start_message, _ = send.messages
+    
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"identity"  # 기존 인코딩 유지
+    assert b"vary" not in headers
+```
+
+---
+
+### 1.6 통합 테스트 (선택사항, `tests/test_middleware_brotli.py`)
+**목적**: 실제 ASGI 앱과 미들웨어를 함께 테스트
+
+**구체적 구현**:
+```python
+import pytest
+from httpx import AsyncClient
+from fastapi import FastAPI
+
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression import CompressionMiddleware
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_integration():
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=10, brotli_level=4)
+    
+    @app.get("/hello")
+    async def hello():
+        return {"message": "Hello, World! " * 100}
+    
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.get("/hello", headers={"Accept-Encoding": "br"})
+        assert resp.headers["content-encoding"] == "br"
+        
+        decompressed = brotli.decompress(resp.content)
+        import json
+        data = json.loads(decompressed.decode())
+        assert data["message"] == "Hello, World! " * 100
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_streaming():
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=1, brotli_level=4)
+    
+    @app.get("/stream")
+    async def stream():
+        from fastapi.responses import StreamingResponse
+        async def gen():
+            for i in range(5):
+                yield f"chunk-{i},".encode()
+        return StreamingResponse(gen(), media_type="text/plain")
+    
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.get("/stream", headers={"Accept-Encoding": "br"})
+        assert resp.headers["content-encoding"] == "br"
+        
+        decompressed = brotli.decompress(resp.content)
+        text = decompressed.decode()
+        assert "chunk-0," in text
+        assert "chunk-4," in text
+```
+
+---
+
+## 2. 구현 순서 및 체크리스트
+
+### Phase 1: HTTP Compression (기본 기능)
+- [ ] `compressors.py`에 `BrotliCompressor` 클래스 추가
+- [ ] `middleware.py`에 `brotli_level` 파라미터 및 `"br"` 등록
+- [ ] `test_compressors.py`에 Brotli 단위 테스트 추가
+- [ ] 기본 압축 동작 확인 (non-streaming)
+
+### Phase 2: Streaming Compression (스트리밍 지원)
+- [ ] `BrotliCompressor`가 incremental API 사용하는지 확인
+- [ ] `test_responder.py` 또는 `test_brotli.py`에 streaming 테스트 추가
+- [ ] 여러 chunk로 나뉜 응답도 정상 압축되는지 확인
+
+### Phase 3: Test Code (테스트 완성)
+- [ ] `test_brotli.py` 파일 생성 및 모든 시나리오 테스트 작성
+- [ ] 통합 테스트 (선택사항) 작성
+- [ ] Edge case 테스트 (minimum_size, Content-Encoding 이미 있는 경우 등)
+- [ ] 모든 테스트 통과 확인
+
+---
+
+## 3. 주의사항 및 고려사항
+
+### 3.1 Optional Dependency 처리
+- `brotli` 패키지가 없어도 미들웨어는 정상 동작해야 함
+- `compressors.py`에서 `BROTLI_AVAILABLE` 플래그를 export하여 실제 패키지 설치 여부를 명확히 표시
+- `middleware.py`에서는 `BROTLI_AVAILABLE` 플래그를 사용하여 `"br"` 등록 여부 결정
+- 테스트에서는 `import brotli`를 직접 시도하여 실제 패키지 설치 여부 확인
+- `BrotliCompressor` 클래스는 항상 import 가능하지만, `brotli` 패키지가 없으면 생성 시 `ImportError` 발생
+
+### 3.2 우선순위 정책
+
+**현재 구현**: 서버가 지원하는 순서대로 체크 (`compressor_factories` 순서)
+
+**우선순위: br > gzip > deflate**
+
+**근거**:
+1. **압축 효율성**: Brotli는 gzip보다 일반적으로 15-20% 더 나은 압축률을 제공합니다.
+2. **최신 표준**: Brotli는 2015년 Google에서 개발된 최신 압축 알고리즘으로, HTTP/2와 함께 널리 사용됩니다.
+3. **브라우저 지원**: 현재 대부분의 모던 브라우저가 Brotli를 지원합니다 (Chrome, Firefox, Edge, Safari 등).
+4. **호환성**: gzip은 여전히 널리 지원되므로 fallback으로 유지합니다.
+5. **deflate의 문제점**: deflate는 gzip과 유사하지만 헤더 형식이 표준화되지 않아 호환성 문제가 있을 수 있습니다.
+
+**참고**: 현재 구현은 q-value 파싱을 하지 않으므로, 서버가 선호하는 순서대로 선택됩니다. 향후 q-value 파싱이 추가되면 더 정교한 협상이 가능합니다.
+
+### 3.3 압축 레벨 기본값
+
+**현재 설정**:
+- `gzip_level: int = 9` (최대 압축률, zlib의 기본값)
+- `deflate_level: int = 6` (중간 압축률, zlib의 기본값)
+- `brotli_level: int = 4` (속도/압축률 균형)
+
+**Brotli level 4 선택 근거**:
+1. **압축률 vs 속도 균형**: 
+   - Level 0-4: 빠른 압축, 적당한 압축률
+   - Level 5-9: 중간 속도, 좋은 압축률
+   - Level 10-11: 느린 압축, 최고 압축률
+   - Level 4는 속도와 압축률의 좋은 균형점입니다.
+
+2. **실제 사용 사례**:
+   - 많은 웹 서버(예: Nginx, Cloudflare)에서 기본값으로 4-6을 사용합니다.
+   - Level 4는 gzip level 9와 비슷한 압축률을 더 빠른 속도로 제공할 수 있습니다.
+
+3. **기존 프로젝트와의 일관성**:
+   - `gzip_level=9`는 최대 압축률을 추구하는 설정입니다.
+   - `brotli_level=4`는 비슷한 압축률을 더 빠르게 달성할 수 있는 설정입니다.
+
+4. **사용자 조정 가능**: 
+   - 사용자가 `brotli_level` 파라미터로 필요에 따라 조정할 수 있습니다.
+   - 대역폭이 중요한 경우: level 6-8 권장
+   - CPU가 제한적인 경우: level 2-4 권장
+   - 최대 압축률이 필요한 경우: level 10-11 권장
+
+**참고**: Brotli의 quality 파라미터는 0-11 범위이며, 기본값 4는 일반적으로 권장되는 값입니다.
+
+### 3.4 기존 코드와의 호환성
+- 기존 `GzipCompressor`, `DeflateCompressor` 동작 변경 없음
+- `CompressionResponder`는 수정 불필요 (이미 범용적으로 구현됨)
+
+---
+
+## 4. 예상 파일 변경 요약
+
+```
+src/asgi_http_compression/
+  ├── compressors.py          [수정] BrotliCompressor 추가
+  ├── middleware.py           [수정] br 등록 및 brotli_level 파라미터
+  └── responder.py            [변경 없음]
+
+tests/
+  ├── test_compressors.py      [수정] BrotliCompressor 테스트 추가
+  ├── test_responder.py        [변경 없음 또는 선택적 수정]
+  └── test_brotli.py          [신규] Brotli end-to-end 테스트
+```
+
+---
+
+## 5. 실제 코드와의 검증 결과
+
+### ✅ 확인된 사항
+
+1. **compressors.py 구조**
+   - `Compressor` Protocol과 `BaseCompressor` ABC가 존재하며, `compress()`와 `flush()` 메서드만 구현하면 됨 ✓
+   - `GzipCompressor`와 `DeflateCompressor`가 `zlib.compressobj`를 사용하는 패턴과 동일하게 구현 가능 ✓
+   - `brotli.Compressor`의 `process()`와 `finish()` API가 스트리밍 압축에 적합함 ✓
+
+2. **middleware.py 구조**
+   - `compressor_factories` 딕셔너리에 lambda 함수로 등록하는 패턴 확인 ✓
+   - `_select_encoding`이 `compressor_factories`의 키를 순회하므로 `"br"` 등록만으로 자동 인식 ✓
+   - 기존 import 방식: `from asgi_http_compression.compressors import DeflateCompressor, GzipCompressor` ✓
+   - `BROTLI_AVAILABLE` 플래그를 사용하여 optional dependency를 안전하게 처리 ✓
+
+3. **responder.py 구조**
+   - `Compressor` Protocol을 사용하므로 추가 수정 불필요 ✓
+   - Streaming/non-streaming 모두 이미 지원됨 ✓
+   - `compress()`와 `flush()` 호출 패턴이 기존과 동일 ✓
+
+4. **테스트 구조**
+   - `test_responder.py`에 `MockSend`, `mock_app`, `streaming_app` 등 재사용 가능한 fixture 존재 ✓
+   - `test_compressors.py`의 fixture 패턴 확인 ✓
+   - `import brotli`를 직접 체크하여 실제 패키지 설치 여부 확인하는 방식 ✓
+
+### ⚠️ 수정된 사항
+
+1. **optional dependency 처리 방식**
+   - `compressors.py`에서 `BROTLI_AVAILABLE` 플래그를 export하여 실제 `brotli` 패키지 설치 여부를 명확히 표시
+   - `middleware.py`에서는 `BROTLI_AVAILABLE` 플래그를 사용하여 `"br"` 등록 여부 결정
+   - `from asgi_http_compression.compressors import BrotliCompressor`는 항상 성공할 수 있으므로, 실제 `brotli` 모듈 존재 여부를 기준으로 판단
+
+2. **테스트에서 BROTLI_AVAILABLE 체크**
+   - `import brotli`를 직접 시도하여 실제 패키지 설치 여부 확인
+   - `from asgi_http_compression.compressors import BrotliCompressor` 성공 여부가 아니라 `import brotli` 성공 여부를 기준으로 `skipif` 적용
+
+3. **테스트 코드 재사용**
+   - `test_responder.py`의 fixture들을 `from tests.test_responder import ...`로 import하여 재사용
+
+---
+
+## 6. 핵심 변경사항 요약
+
+### Optional Dependency 처리 방식 (중요!)
+
+**문제점**: `compressors.py`에서 `try/except ImportError`로 `brotli`를 처리하면, `brotli` 패키지가 없어도 `BrotliCompressor` 클래스는 항상 import 가능합니다. 이 경우 `BrotliCompressor is None` 체크가 작동하지 않습니다.
+
+**해결책**:
+1. **`compressors.py`**: `BROTLI_AVAILABLE = brotli is not None` 플래그를 export
+2. **`middleware.py`**: `BROTLI_AVAILABLE` 플래그를 사용하여 `"br"` 등록 여부 결정
+3. **테스트**: `import brotli`를 직접 시도하여 실제 패키지 설치 여부 확인
+
+이렇게 하면 `brotli` 패키지가 없을 때:
+- `compressors.py` 모듈은 정상 import됨
+- `BROTLI_AVAILABLE = False`로 설정됨
+- `middleware.py`에서 `"br"` 등록을 건너뜀 (graceful degradation)
+- 테스트는 자동으로 skip됨
+
+---
+
+## 7. 검증 체크리스트
+
+구현 완료 후 다음을 확인:
+
+- [ ] `Accept-Encoding: br` 요청 시 `Content-Encoding: br` 응답
+- [ ] Brotli로 압축된 응답을 `brotli.decompress()`로 정상 복원 가능
+- [ ] StreamingResponse도 Brotli 압축 정상 동작
+- [ ] `brotli` 패키지 없을 때 graceful degradation (에러 없이 gzip/deflate만 사용)
+- [ ] `minimum_size` 조건 정상 동작
+- [ ] 이미 `Content-Encoding`이 있는 응답은 건드리지 않음
+- [ ] 모든 기존 테스트 통과 (회귀 테스트)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
     "pytest-asyncio>=1.3.0",
+    "fastapi>=0.124.0",
 ]
 lint = [
     "ruff>=0.14.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
     "pytest-asyncio>=1.3.0",
-    "fastapi>=0.124.0",
+    "starlette>=0.50.0",
 ]
 lint = [
     "ruff>=0.14.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = ["asgi", "middleware", "compression", "gzip", "brotli", "zstd", "zstandard", "fastapi", "starlette"]
-dependencies = []
+dependencies = [
+]
 
 [project.urls]
 Homepage = "https://github.com/timothy-jeong/asgi-http-compression"
 Repository = "https://github.com/timothy-jeong/asgi-http-compression"
 
 [project.optional-dependencies]
-brotli = ["brotli"]
+brotli = ["brotli>=1.2.0"]
 zstd = ["zstandard"]
 
 test = [

--- a/src/asgi_http_compression/__init__.py
+++ b/src/asgi_http_compression/__init__.py
@@ -1,0 +1,3 @@
+from asgi_http_compression.middleware import CompressionMiddleware
+
+__all__ = ["CompressionMiddleware"]

--- a/src/asgi_http_compression/compressors.py
+++ b/src/asgi_http_compression/compressors.py
@@ -2,6 +2,13 @@ import zlib
 from abc import ABC, abstractmethod
 from typing import Protocol
 
+try:
+    import brotli
+except ImportError:
+    brotli = None
+
+BROTLI_AVAILABLE = brotli is not None
+
 
 class Compressor(Protocol):
     def compress(self, data: bytes) -> bytes: ...
@@ -37,3 +44,20 @@ class DeflateCompressor(BaseCompressor):
 
     def flush(self) -> bytes:
         return self._compressobj.flush()
+
+
+class BrotliCompressor(BaseCompressor):
+    def __init__(self, level: int = 4) -> None:
+        if brotli is None:
+            raise ImportError(
+                "brotli extra is required. Install with: pip install 'asgi-http-compression[brotli]'"
+            )
+        self._compressor = brotli.Compressor(quality=level)
+
+    def compress(self, data: bytes) -> bytes:
+        """스트리밍 압축을 위한 incremental compress"""
+        return self._compressor.process(data)
+
+    def flush(self) -> bytes:
+        """압축 완료 및 남은 데이터 반환"""
+        return self._compressor.finish()

--- a/src/asgi_http_compression/compressors.py
+++ b/src/asgi_http_compression/compressors.py
@@ -55,9 +55,7 @@ class BrotliCompressor(BaseCompressor):
         self._compressor = brotli.Compressor(quality=level)
 
     def compress(self, data: bytes) -> bytes:
-        """스트리밍 압축을 위한 incremental compress"""
         return self._compressor.process(data)
 
     def flush(self) -> bytes:
-        """압축 완료 및 남은 데이터 반환"""
         return self._compressor.finish()

--- a/src/asgi_http_compression/middleware.py
+++ b/src/asgi_http_compression/middleware.py
@@ -30,8 +30,6 @@ class CompressionMiddleware:
         # NOTE: The order is important: list the ones the server prefers first
         self.compressor_factories: dict[str, Callable[[], Any]] = {}
 
-        # Brotli를 가장 먼저 등록 (우선순위 높음)
-        # BROTLI_AVAILABLE 플래그로 실제 brotli 패키지 설치 여부 확인
         if BROTLI_AVAILABLE:
             self.compressor_factories["br"] = lambda: BrotliCompressor(
                 level=brotli_level

--- a/tests/test_brotli.py
+++ b/tests/test_brotli.py
@@ -10,7 +10,6 @@ except ImportError:
 
 from asgi_http_compression.responder import CompressionResponder
 
-# test_responder.py의 MockSend, mock_app, streaming_app 등을 재사용
 from test_responder import (
     MockSend,
     app_with_encoding,
@@ -22,7 +21,6 @@ from test_responder import (
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_brotli_basic_compression():
-    """기본 Brotli 압축 테스트"""
     compressor = BrotliCompressor(level=4)
     send = MockSend()
     responder = CompressionResponder(
@@ -42,7 +40,6 @@ async def test_brotli_basic_compression():
     assert headers[b"vary"] == b"Accept-Encoding"
     assert b"content-length" in headers
 
-    # 압축 해제 확인
     compressed_body = body_message["body"]
     decompressed = brotli.decompress(compressed_body)
     assert decompressed == b"Hello, World!"
@@ -51,7 +48,6 @@ async def test_brotli_basic_compression():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_brotli_streaming_response():
-    """StreamingResponse 테스트"""
     compressor = BrotliCompressor(level=4)
     send = MockSend()
     responder = CompressionResponder(
@@ -73,7 +69,6 @@ async def test_brotli_streaming_response():
     assert body1["more_body"]
     assert body2["more_body"] is False
 
-    # 전체 압축 데이터 수집 및 압축 해제
     full_compressed = body1["body"] + body2["body"]
     decompressed = brotli.decompress(full_compressed)
     assert decompressed == b"Streaming part 2"
@@ -82,7 +77,6 @@ async def test_brotli_streaming_response():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_brotli_respects_existing_content_encoding():
-    """이미 Content-Encoding이 있는 응답 처리"""
     compressor = BrotliCompressor(level=4)
     send = MockSend()
     responder = CompressionResponder(
@@ -98,14 +92,13 @@ async def test_brotli_respects_existing_content_encoding():
     start_message, _ = send.messages
 
     headers = dict(start_message["headers"])
-    assert headers[b"content-encoding"] == b"identity"  # 기존 인코딩 유지
+    assert headers[b"content-encoding"] == b"identity"
     assert b"vary" not in headers
 
 
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_brotli_skips_small_response():
-    """minimum_size 조건 테스트"""
     compressor = BrotliCompressor(level=4)
     send = MockSend()
     responder = CompressionResponder(
@@ -130,10 +123,8 @@ async def test_brotli_skips_small_response():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_brotli_incremental_compression():
-    """여러 chunk로 나뉜 응답의 incremental 압축 테스트"""
     compressor = BrotliCompressor(level=4)
 
-    # 여러 chunk로 나눠서 압축
     chunk1 = b"First chunk of data. "
     chunk2 = b"Second chunk of data. "
     chunk3 = b"Third chunk of data."

--- a/tests/test_brotli.py
+++ b/tests/test_brotli.py
@@ -1,0 +1,149 @@
+import pytest
+
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression.compressors import BrotliCompressor
+
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+from asgi_http_compression.responder import CompressionResponder
+
+# test_responder.py의 MockSend, mock_app, streaming_app 등을 재사용
+from test_responder import (
+    MockSend,
+    app_with_encoding,
+    mock_app,
+    streaming_app,
+)
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_basic_compression():
+    """기본 Brotli 압축 테스트"""
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=mock_app,
+        compressor=compressor,
+        minimum_size=5,
+        encoding_name="br",
+    )
+
+    await responder(scope={}, receive=None, send=send)
+
+    assert len(send.messages) == 2
+    start_message, body_message = send.messages
+
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"br"
+    assert headers[b"vary"] == b"Accept-Encoding"
+    assert b"content-length" in headers
+
+    # 압축 해제 확인
+    compressed_body = body_message["body"]
+    decompressed = brotli.decompress(compressed_body)
+    assert decompressed == b"Hello, World!"
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_streaming_response():
+    """StreamingResponse 테스트"""
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=streaming_app,
+        compressor=compressor,
+        minimum_size=1,
+        encoding_name="br",
+    )
+
+    await responder(scope={}, receive=None, send=send)
+
+    assert len(send.messages) == 3
+    start_message, body1, body2 = send.messages
+
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"br"
+    assert b"content-length" not in headers
+
+    assert body1["more_body"]
+    assert body2["more_body"] is False
+
+    # 전체 압축 데이터 수집 및 압축 해제
+    full_compressed = body1["body"] + body2["body"]
+    decompressed = brotli.decompress(full_compressed)
+    assert decompressed == b"Streaming part 2"
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_respects_existing_content_encoding():
+    """이미 Content-Encoding이 있는 응답 처리"""
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=app_with_encoding,
+        compressor=compressor,
+        minimum_size=1,
+        encoding_name="br",
+    )
+
+    await responder(scope={}, receive=None, send=send)
+
+    assert len(send.messages) == 2
+    start_message, _ = send.messages
+
+    headers = dict(start_message["headers"])
+    assert headers[b"content-encoding"] == b"identity"  # 기존 인코딩 유지
+    assert b"vary" not in headers
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_skips_small_response():
+    """minimum_size 조건 테스트"""
+    compressor = BrotliCompressor(level=4)
+    send = MockSend()
+    responder = CompressionResponder(
+        app=mock_app,
+        compressor=compressor,
+        minimum_size=100,
+        encoding_name="br",
+    )
+
+    await responder(scope={}, receive=None, send=send)
+
+    assert len(send.messages) == 2
+    start_message, body_message = send.messages
+
+    headers = dict(start_message["headers"])
+    assert b"content-encoding" not in headers
+    assert b"vary" not in headers
+
+    assert body_message["body"] == b"Hello, World!"
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_brotli_incremental_compression():
+    """여러 chunk로 나뉜 응답의 incremental 압축 테스트"""
+    compressor = BrotliCompressor(level=4)
+
+    # 여러 chunk로 나눠서 압축
+    chunk1 = b"First chunk of data. "
+    chunk2 = b"Second chunk of data. "
+    chunk3 = b"Third chunk of data."
+
+    compressed1 = compressor.compress(chunk1)
+    compressed2 = compressor.compress(chunk2)
+    compressed3 = compressor.compress(chunk3)
+    flushed = compressor.flush()
+
+    full_compressed = compressed1 + compressed2 + compressed3 + flushed
+    decompressed = brotli.decompress(full_compressed)
+
+    assert decompressed == chunk1 + chunk2 + chunk3

--- a/tests/test_compressors.py
+++ b/tests/test_compressors.py
@@ -4,8 +4,19 @@ import pytest
 
 from asgi_http_compression.compressors import DeflateCompressor, GzipCompressor
 
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression.compressors import BrotliCompressor
 
-@pytest.fixture(params=[GzipCompressor, DeflateCompressor])
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+
+@pytest.fixture(
+    params=[GzipCompressor, DeflateCompressor]
+    + ([BrotliCompressor] if BROTLI_AVAILABLE else [])
+)
 def compressor(request):
     return request.param()
 
@@ -20,6 +31,8 @@ def test_compressor_simple_compression(compressor):
     if isinstance(compressor, GzipCompressor):
         # 15 + 16 tells zlib to use the gzip header and trailer format.
         decompressed = zlib.decompress(full_compressed_data, 15 + 16)
+    elif isinstance(compressor, BrotliCompressor):
+        decompressed = brotli.decompress(full_compressed_data)
     else:
         decompressed = zlib.decompress(full_compressed_data)
 
@@ -40,6 +53,8 @@ def test_compressor_incremental_compression(compressor):
 
     if isinstance(compressor, GzipCompressor):
         decompressed = zlib.decompress(full_compressed_data, 15 + 16)
+    elif isinstance(compressor, BrotliCompressor):
+        decompressed = brotli.decompress(full_compressed_data)
     else:
         decompressed = zlib.decompress(full_compressed_data)
 
@@ -55,8 +70,38 @@ def test_compressor_empty_data(compressor):
 
     if isinstance(compressor, GzipCompressor):
         decompressed = zlib.decompress(full_compressed_data, 15 + 16)
+    elif isinstance(compressor, BrotliCompressor):
+        decompressed = brotli.decompress(full_compressed_data)
     else:
         decompressed = zlib.decompress(full_compressed_data)
 
     assert decompressed == original_data
     assert full_compressed_data != original_data
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+def test_brotli_compressor():
+    compressor = BrotliCompressor(level=4)
+    original_data = b"Hello, World!" * 10
+    compressed = compressor.compress(original_data)
+    flushed = compressor.flush()
+    full_compressed_data = compressed + flushed
+    decompressed = brotli.decompress(full_compressed_data)
+    assert decompressed == original_data
+    assert original_data != full_compressed_data
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+def test_brotli_incremental_compression():
+    compressor = BrotliCompressor(level=4)
+    data_part1 = b"This is the first part."
+    data_part2 = b"This is the second part."
+    original_data = data_part1 + data_part2
+
+    compressed1 = compressor.compress(data_part1)
+    compressed2 = compressor.compress(data_part2)
+    flushed = compressor.flush()
+
+    full_compressed_data = compressed1 + compressed2 + flushed
+    decompressed = brotli.decompress(full_compressed_data)
+    assert decompressed == original_data

--- a/tests/test_middleware_brotli.py
+++ b/tests/test_middleware_brotli.py
@@ -17,7 +17,6 @@ except ImportError:
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_middleware_brotli_integration():
-    """미들웨어와 실제 ASGI 앱을 함께 테스트"""
 
     async def hello_handler(request):
         return JSONResponse({"message": "Hello, World! " * 100})
@@ -40,7 +39,6 @@ async def test_middleware_brotli_integration():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_middleware_brotli_streaming():
-    """미들웨어와 StreamingResponse 테스트"""
 
     async def stream_handler(request):
         async def gen():
@@ -68,7 +66,6 @@ async def test_middleware_brotli_streaming():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_middleware_brotli_priority():
-    """우선순위 테스트: br이 gzip보다 우선 선택되는지 확인"""
 
     async def hello_handler(request):
         return JSONResponse({"message": "Hello, World! " * 100})
@@ -81,11 +78,9 @@ async def test_middleware_brotli_priority():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        # br과 gzip을 모두 지원하는 클라이언트
         resp = await client.get("/hello", headers={"Accept-Encoding": "br, gzip"})
         assert resp.headers["content-encoding"] == "br"
 
-        # gzip과 br을 모두 지원하지만 순서가 다른 경우
         resp2 = await client.get("/hello", headers={"Accept-Encoding": "gzip, br"})
         assert resp2.headers["content-encoding"] == "br"
 
@@ -93,8 +88,6 @@ async def test_middleware_brotli_priority():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_middleware_brotli_not_supported_client():
-    """Brotli를 지원하지 않는 클라이언트는 gzip 사용"""
-
     async def hello_handler(request):
         return JSONResponse({"message": "Hello, World! " * 100})
 
@@ -106,7 +99,6 @@ async def test_middleware_brotli_not_supported_client():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        # gzip만 지원하는 클라이언트
         resp = await client.get("/hello", headers={"Accept-Encoding": "gzip"})
         assert resp.headers["content-encoding"] == "gzip"
         assert resp.headers["content-encoding"] != "br"
@@ -115,7 +107,6 @@ async def test_middleware_brotli_not_supported_client():
 @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
 @pytest.mark.asyncio
 async def test_middleware_brotli_minimum_size():
-    """minimum_size 조건 테스트"""
 
     async def small_handler(request):
         return JSONResponse({"message": "small"})
@@ -131,5 +122,4 @@ async def test_middleware_brotli_minimum_size():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
         resp = await client.get("/small", headers={"Accept-Encoding": "br"})
-        # 작은 응답은 압축되지 않음
         assert "content-encoding" not in resp.headers

--- a/tests/test_middleware_brotli.py
+++ b/tests/test_middleware_brotli.py
@@ -1,0 +1,121 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from httpx import ASGITransport, AsyncClient
+
+try:
+    import brotli  # type: ignore[import-untyped]
+    from asgi_http_compression import CompressionMiddleware
+
+    BROTLI_AVAILABLE = True
+except ImportError:
+    BROTLI_AVAILABLE = False
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_integration():
+    """미들웨어와 실제 ASGI 앱을 함께 테스트"""
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=10, brotli_level=4)
+
+    @app.get("/hello")
+    async def hello():
+        return {"message": "Hello, World! " * 100}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/hello", headers={"Accept-Encoding": "br"})
+        assert resp.headers["content-encoding"] == "br"
+
+        data = resp.json()
+        assert data["message"] == "Hello, World! " * 100
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_streaming():
+    """미들웨어와 StreamingResponse 테스트"""
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=1, brotli_level=4)
+
+    @app.get("/stream")
+    async def stream():
+        async def gen():
+            for i in range(5):
+                yield f"chunk-{i},".encode()
+
+        return StreamingResponse(gen(), media_type="text/plain")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/stream", headers={"Accept-Encoding": "br"})
+        assert resp.headers["content-encoding"] == "br"
+
+        text = resp.text
+        assert "chunk-0," in text
+        assert "chunk-4," in text
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_priority():
+    """우선순위 테스트: br이 gzip보다 우선 선택되는지 확인"""
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=10, brotli_level=4)
+
+    @app.get("/hello")
+    async def hello():
+        return {"message": "Hello, World! " * 100}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # br과 gzip을 모두 지원하는 클라이언트
+        resp = await client.get("/hello", headers={"Accept-Encoding": "br, gzip"})
+        assert resp.headers["content-encoding"] == "br"
+
+        # gzip과 br을 모두 지원하지만 순서가 다른 경우
+        resp2 = await client.get("/hello", headers={"Accept-Encoding": "gzip, br"})
+        assert resp2.headers["content-encoding"] == "br"
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_not_supported_client():
+    """Brotli를 지원하지 않는 클라이언트는 gzip 사용"""
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=10, brotli_level=4)
+
+    @app.get("/hello")
+    async def hello():
+        return {"message": "Hello, World! " * 100}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # gzip만 지원하는 클라이언트
+        resp = await client.get("/hello", headers={"Accept-Encoding": "gzip"})
+        assert resp.headers["content-encoding"] == "gzip"
+        assert resp.headers["content-encoding"] != "br"
+
+
+@pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli package not installed")
+@pytest.mark.asyncio
+async def test_middleware_brotli_minimum_size():
+    """minimum_size 조건 테스트"""
+    app = FastAPI()
+    app.add_middleware(CompressionMiddleware, minimum_size=1000, brotli_level=4)
+
+    @app.get("/small")
+    async def small():
+        return {"message": "small"}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/small", headers={"Accept-Encoding": "br"})
+        # 작은 응답은 압축되지 않음
+        assert "content-encoding" not in resp.headers

--- a/uv.lock
+++ b/uv.lock
@@ -3,24 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -47,12 +29,12 @@ brotli = [
 dev = [
     { name = "anyio" },
     { name = "brotli" },
-    { name = "fastapi" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "starlette" },
     { name = "zstandard" },
 ]
 lint = [
@@ -60,11 +42,11 @@ lint = [
 ]
 test = [
     { name = "anyio" },
-    { name = "fastapi" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "starlette" },
 ]
 zstd = [
     { name = "zstandard" },
@@ -78,12 +60,12 @@ requires-dist = [
     { name = "asgi-http-compression", extras = ["test"], marker = "extra == 'dev'" },
     { name = "asgi-http-compression", extras = ["zstd"], marker = "extra == 'dev'" },
     { name = "brotli", marker = "extra == 'brotli'" },
-    { name = "fastapi", marker = "extra == 'test'", specifier = ">=0.124.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.14.6" },
+    { name = "starlette", marker = "extra == 'test'", specifier = ">=0.50.0" },
     { name = "zstandard", marker = "extra == 'zstd'" },
 ]
 provides-extras = ["brotli", "zstd", "test", "lint", "dev"]
@@ -290,21 +272,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastapi"
-version = "0.124.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/9c/11969bd3e3bc4aa3a711f83dd3720239d3565a934929c74fc32f6c9f3638/fastapi-0.124.0.tar.gz", hash = "sha256:260cd178ad75e6d259991f2fd9b0fee924b224850079df576a3ba604ce58f4e6", size = 357623, upload-time = "2025-12-06T13:11:35.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/29/9e1e82e16e9a1763d3b55bfbe9b2fa39d7175a1fd97685c482fa402e111d/fastapi-0.124.0-py3-none-any.whl", hash = "sha256:91596bdc6dde303c318f06e8d2bc75eafb341fc793a0c9c92c0bc1db1ac52480", size = 112505, upload-time = "2025-12-06T13:11:34.392Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -375,139 +342,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pydantic"
-version = "2.12.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
-    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
-    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
-    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
-    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
-    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
-    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
-    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
-    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
-    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
-    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
-    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
-    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
-    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
-    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
-    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
-    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
-    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
-    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
 ]
 
 [[package]]
@@ -669,18 +503,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,24 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
 
 [[package]]
 name = "anyio"
@@ -29,6 +47,7 @@ brotli = [
 dev = [
     { name = "anyio" },
     { name = "brotli" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -41,6 +60,7 @@ lint = [
 ]
 test = [
     { name = "anyio" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -58,6 +78,7 @@ requires-dist = [
     { name = "asgi-http-compression", extras = ["test"], marker = "extra == 'dev'" },
     { name = "asgi-http-compression", extras = ["zstd"], marker = "extra == 'dev'" },
     { name = "brotli", marker = "extra == 'brotli'" },
+    { name = "fastapi", marker = "extra == 'test'", specifier = ">=0.124.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
@@ -269,6 +290,21 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.124.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/9c/11969bd3e3bc4aa3a711f83dd3720239d3565a934929c74fc32f6c9f3638/fastapi-0.124.0.tar.gz", hash = "sha256:260cd178ad75e6d259991f2fd9b0fee924b224850079df576a3ba604ce58f4e6", size = 357623, upload-time = "2025-12-06T13:11:35.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/29/9e1e82e16e9a1763d3b55bfbe9b2fa39d7175a1fd97685c482fa402e111d/fastapi-0.124.0-py3-none-any.whl", hash = "sha256:91596bdc6dde303c318f06e8d2bc75eafb341fc793a0c9c92c0bc1db1ac52480", size = 112505, upload-time = "2025-12-06T13:11:34.392Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -339,6 +375,139 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
 ]
 
 [[package]]
@@ -432,6 +601,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -487,6 +669,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Brotli 압축 기능 추가 - 변경사항 요약

## 개요

이번 변경사항은 `asgi-http-compression` 미들웨어에 **Brotli 압축 기능**을 추가한 것입니다. 기존의 `gzip`과 `deflate` 압축에 더해, 더 나은 압축률을 제공하는 Brotli 압축을 지원합니다.

## 주요 변경사항

### ✨ 새로운 기능

1. **Brotli 압축 지원**
   - HTTP `Content-Encoding: br` 지원
   - 기존 `gzip`, `deflate`와 동일한 인터페이스로 사용 가능
   - Optional dependency로 구현되어 `brotli` 패키지가 없어도 미들웨어는 정상 동작

2. **압축 우선순위**
   - 서버 우선순위: `br` > `gzip` > `deflate`
   - 클라이언트가 여러 압축 방식을 지원할 경우, Brotli가 최우선으로 선택됨

3. **스트리밍 압축 지원**
   - 기존 `gzip`, `deflate`와 동일하게 스트리밍 응답도 지원
   - Incremental compression으로 메모리 효율적 처리

### 📝 수정된 파일

#### 1. `src/asgi_http_compression/compressors.py`
- `BrotliCompressor` 클래스 추가
- `BROTLI_AVAILABLE` 플래그 추가 (optional dependency 처리)
- `brotli.Compressor` API를 사용한 incremental compression 구현

**주요 코드:**
```python
class BrotliCompressor(BaseCompressor):
    def __init__(self, level: int = 4) -> None:
        if brotli is None:
            raise ImportError(
                "brotli extra is required. Install with: pip install 'asgi-http-compression[brotli]'"
            )
        self._compressor = brotli.Compressor(quality=level)
    
    def compress(self, data: bytes) -> bytes:
        return self._compressor.process(data)
    
    def flush(self) -> bytes:
        return self._compressor.finish()
```

#### 2. `src/asgi_http_compression/middleware.py`
- `brotli_level` 파라미터 추가 (기본값: 4)
- `compressor_factories`에 `"br"` 등록
- `BROTLI_AVAILABLE` 플래그로 graceful degradation 구현

**주요 변경:**
```python
def __init__(
    self,
    app: ASGIApp,
    minimum_size: int = 500,
    gzip_level: int = 9,
    deflate_level: int = 6,
    brotli_level: int = 4,  # 새로 추가
) -> None:
    # ...
    if BROTLI_AVAILABLE:
        self.compressor_factories["br"] = lambda: BrotliCompressor(level=brotli_level)
    # ...
```

#### 3. `src/asgi_http_compression/__init__.py`
- `CompressionMiddleware` export 추가

#### 4. `pyproject.toml`
- `brotli` optional dependency 추가
- `test` extra에 `starlette>=0.50.0` 추가 (통합 테스트용)
- `fastapi` 제거 (Starlette로 대체)

**변경 내용:**
```toml
[project.optional-dependencies]
brotli = ["brotli"]  # 새로 추가

test = [
    # ...
    "starlette>=0.50.0",  # fastapi 대신 starlette 사용
]
```

### 🧪 테스트 파일

#### 1. `tests/test_compressors.py` (수정)
- `BrotliCompressor`를 fixture에 추가
- Brotli 전용 테스트 케이스 추가
- 압축 해제 로직에 Brotli 분기 추가

#### 2. `tests/test_brotli.py` (신규)
- Brotli 압축기 단위 테스트
- 기본 압축, 스트리밍, edge case 테스트

#### 3. `tests/test_middleware_brotli.py` (신규)
- 미들웨어 통합 테스트
- Starlette 기반 ASGI 앱으로 테스트
- 우선순위, 비지원 클라이언트, minimum_size 테스트

### 📚 문서

#### `DESIGN_BROTLI.md` (신규)
- Brotli 기능 추가에 대한 상세 설계 문서
- 구현 계획, 주의사항, 검증 체크리스트 포함

## 사용 방법

### 설치

```bash
# Brotli 지원 포함 설치
pip install 'asgi-http-compression[brotli]'

# 또는 uv 사용
uv pip install 'asgi-http-compression[brotli]'
```

### 기본 사용

```python
from asgi_http_compression import CompressionMiddleware
from starlette.applications import Starlette
from starlette.middleware import Middleware

app = Starlette(
    middleware=[
        Middleware(
            CompressionMiddleware,
            minimum_size=500,
            brotli_level=4,  # Brotli 압축 레벨 (0-11, 기본값: 4)
            gzip_level=9,
            deflate_level=6,
        )
    ]
)
```

### 압축 레벨 조정

```python
# 빠른 압축 (낮은 CPU 사용)
Middleware(CompressionMiddleware, brotli_level=2)

# 균형잡힌 설정 (기본값)
Middleware(CompressionMiddleware, brotli_level=4)

# 최대 압축률 (높은 CPU 사용)
Middleware(CompressionMiddleware, brotli_level=11)
```

## 기술적 세부사항

### Optional Dependency 처리

- `brotli` 패키지가 없어도 미들웨어는 정상 동작
- `brotli` 패키지가 설치되지 않은 경우:
  - `BROTLI_AVAILABLE = False`
  - `"br"` 압축 방식이 등록되지 않음
  - `gzip`, `deflate`만 사용 가능 (graceful degradation)

### 압축 우선순위 정책

**서버 우선순위: `br` > `gzip` > `deflate`**

**근거:**
1. **압축 효율성**: Brotli는 gzip보다 일반적으로 15-20% 더 나은 압축률 제공
2. **최신 표준**: HTTP/2와 함께 널리 사용되는 최신 압축 알고리즘
3. **브라우저 지원**: 대부분의 모던 브라우저가 Brotli 지원
4. **호환성**: gzip은 여전히 널리 지원되므로 fallback으로 유지

### 압축 레벨 기본값

- **`brotli_level: int = 4`**: 속도와 압축률의 균형점
- **`gzip_level: int = 9`**: 최대 압축률 (기존 유지)
- **`deflate_level: int = 6`**: 중간 압축률 (기존 유지)

**Brotli level 4 선택 근거:**
- Level 0-4: 빠른 압축, 적당한 압축률
- Level 5-9: 중간 속도, 좋은 압축률
- Level 10-11: 느린 압축, 최고 압축률
- Level 4는 gzip level 9와 비슷한 압축률을 더 빠른 속도로 제공

## 테스트

### 테스트 실행

```bash
# 모든 테스트 실행
uv run pytest

# Brotli 관련 테스트만 실행
uv run pytest tests/test_brotli.py tests/test_middleware_brotli.py

# 특정 테스트 실행
uv run pytest tests/test_middleware_brotli.py::test_middleware_brotli_integration
```

### 테스트 커버리지

- 단위 테스트: `test_compressors.py`, `test_brotli.py`
- 통합 테스트: `test_middleware_brotli.py`
- Edge case 테스트: minimum_size, Content-Encoding 이미 있는 경우 등

## 호환성

### 하위 호환성
- ✅ 기존 API 변경 없음
- ✅ 기존 `gzip`, `deflate` 동작 유지
- ✅ `brotli` 패키지 없을 때 graceful degradation

### Python 버전
- Python 3.10+ (기존 요구사항 유지)

### 의존성
- **필수**: 없음 (기존과 동일)
- **Optional**: `brotli` (Brotli 압축 사용 시)

## 마이그레이션 가이드

### 기존 코드에서 Brotli 사용하기

기존 코드는 수정 없이 동작합니다. Brotli를 사용하려면:

1. **`brotli` 패키지 설치**
   ```bash
   pip install 'asgi-http-compression[brotli]'
   ```

2. **미들웨어 설정 (선택사항)**
   ```python
   # brotli_level 파라미터 추가 (기본값 4 사용 시 생략 가능)
   Middleware(CompressionMiddleware, brotli_level=4)
   ```

3. **자동으로 Brotli 사용**
   - 클라이언트가 `Accept-Encoding: br`을 보내면 자동으로 Brotli 압축 사용
   - 클라이언트가 `Accept-Encoding: br, gzip`을 보내면 Brotli 우선 사용

## 변경 파일 목록

### 신규 파일
- `DESIGN_BROTLI.md` - 설계 문서
- `tests/test_brotli.py` - Brotli 단위 테스트
- `tests/test_middleware_brotli.py` - 미들웨어 통합 테스트

### 수정 파일
- `src/asgi_http_compression/compressors.py` - BrotliCompressor 추가
- `src/asgi_http_compression/middleware.py` - br 등록 및 brotli_level 파라미터
- `src/asgi_http_compression/__init__.py` - CompressionMiddleware export
- `tests/test_compressors.py` - Brotli 테스트 추가
- `pyproject.toml` - brotli optional dependency, starlette 추가
- `uv.lock` - 의존성 잠금 파일 업데이트

## 검증 체크리스트

- [x] `Accept-Encoding: br` 요청 시 `Content-Encoding: br` 응답
- [x] Brotli로 압축된 응답을 `brotli.decompress()`로 정상 복원 가능
- [x] StreamingResponse도 Brotli 압축 정상 동작
- [x] `brotli` 패키지 없을 때 graceful degradation (에러 없이 gzip/deflate만 사용)
- [x] `minimum_size` 조건 정상 동작
- [x] 이미 `Content-Encoding`이 있는 응답은 건드리지 않음
- [x] 모든 기존 테스트 통과 (회귀 테스트)
- [x] 우선순위 정책 정상 동작 (br > gzip > deflate)


**작성일**: 2025-12-09
**브랜치**: `feature/3/add-brotli-compression`  
**관련 이슈**: #3

